### PR TITLE
Add option to use fill-column for line length

### DIFF
--- a/blacken.el
+++ b/blacken.el
@@ -38,6 +38,8 @@
 ;;
 ;;; Code:
 
+(require 'cl-lib)
+
 
 (defgroup blacken nil
   "Reformat Python code with \"black\"."
@@ -48,9 +50,15 @@
   :type 'string)
 
 (defcustom blacken-line-length nil
-  "Line length to enforce."
-  :type 'number
-  :safe 'numberp)
+  "Line length to enforce.
+
+It must be an integer, nil or `fill'.
+If `fill', the `fill-column' variable value is used."
+  :type '(choice :tag "Line Length Limit"
+           (const :tag "Use default" nil)
+           (const :tag "Use fill-column" fill)
+           (integer :tag "Line Length"))
+  :safe 'integerp)
 
 (defcustom blacken-allow-py36 nil
   "Allow using Python 3.6-only syntax on all input files."
@@ -95,7 +103,10 @@ Return black process the exit code."
   "Build black process call arguments."
   (append
    (when blacken-line-length
-     (list "--line-length" (number-to-string blacken-line-length)))
+     (list "--line-length"
+           (number-to-string (cl-case blacken-line-length
+                               ('fill fill-column)
+                               (t blacken-line-length)))))
    (when blacken-allow-py36
      (list "--py36"))
    (when blacken-fast-unsafe


### PR DESCRIPTION
Using `fill-column` is Emacs standart for line length.
`whitespace-mode` does the same thing (either specify manually or on NIL use `fill-column`).

I changed the default to `88` instead of `nil` because that's `black`s default
so it should not break someones config or suddenly change the formatting
of someones code if he doesn't configure it.