### PR TITLE
Add initial support for blacken-region

### DIFF
--- a/blacken.el
+++ b/blacken.el
@@ -149,19 +149,14 @@ Show black output, if black exit abnormally and DISPLAY is t."
   (interactive (if (use-region-p)
                    (list (region-beginning) (region-end))
                  (list nil nil)))
-  (let* ((origbuf (current-buffer))
-         (origbeg beg)
-         (origend end)
-         (regionbuf (get-buffer-create "*blacken-region*"))
-         (content (buffer-substring-no-properties beg end)))
-    (with-current-buffer regionbuf
-      (erase-buffer)
-      (insert content)
-      (blacken-buffer)
-      (with-current-buffer origbuf
-        (delete-region origbeg origend)
-        (insert-buffer-substring regionbuf)))
-    (kill-buffer regionbuf)))
+  (let* ((content (buffer-substring-no-properties beg end))
+         (blackened (with-temp-buffer
+                      (insert content)
+                      (blacken-buffer)
+                      (buffer-string))))
+    (with-current-buffer (current-buffer)
+      (delete-region beg end)
+      (insert blackened))))
 
 ;;;###autoload
 (define-minor-mode blacken-mode

--- a/blacken.el
+++ b/blacken.el
@@ -150,9 +150,18 @@ Show black output, if black exit abnormally and DISPLAY is t."
                    (list (region-beginning) (region-end))
                  (list nil nil)))
   (let* ((content (buffer-substring-no-properties beg end))
+         (indentation (with-temp-buffer
+                         (insert content)
+                         (goto-char (point-min))
+                         (back-to-indentation)
+                         (- (point) 1)))
          (blackened (with-temp-buffer
                       (insert content)
+                      (dotimes (i indentation)
+                        (indent-rigidly-left (point-min) (point-max)))
                       (blacken-buffer)
+                      (dotimes (i indentation)
+                        (indent-rigidly-right (point-min) (point-max)))
                       (buffer-string))))
     (with-current-buffer (current-buffer)
       (delete-region beg end)

--- a/blacken.el
+++ b/blacken.el
@@ -144,6 +144,26 @@ Show black output, if black exit abnormally and DISPLAY is t."
                (pop-to-buffer errbuf))))))
 
 ;;;###autoload
+(defun blacken-region (beg end)
+  "Try to blacken the current region (between BEG and END)."
+  (interactive (if (use-region-p)
+                   (list (region-beginning) (region-end))
+                 (list nil nil)))
+  (let* ((origbuf (current-buffer))
+         (origbeg beg)
+         (origend end)
+         (regionbuf (get-buffer-create "*blacken-region*"))
+         (content (buffer-substring-no-properties beg end)))
+    (with-current-buffer regionbuf
+      (erase-buffer)
+      (insert content)
+      (blacken-buffer)
+      (with-current-buffer origbuf
+        (delete-region origbeg origend)
+        (insert-buffer-substring regionbuf)))
+    (kill-buffer regionbuf)))
+
+;;;###autoload
 (define-minor-mode blacken-mode
   "Automatically run black before saving."
   :lighter " Black"


### PR DESCRIPTION
Resolves https://github.com/proofit404/blacken/issues/11

Hacked together this quick implementation of blacken-region, but also my first serious attempt at elisp aside from my personal emacs configuration.

This will only work with valid top-level python blocks, as it copies the region to a new buffer, with leading whitespaces and all.

Would be nice to handle it, as mentioned [here](https://github.com/proofit404/blacken/issues/11#issuecomment-424221748), but frankly I don't know enough about elisp to implement it myself

Feel free to suggest improvements!