### PR TITLE
Detect if the current file is a pyi to format accordingly

### DIFF
--- a/blacken.el
+++ b/blacken.el
@@ -112,6 +112,8 @@ Return black process the exit code."
      (list "--fast"))
    (when blacken-skip-string-normalization
      (list "--skip-string-normalization"))
+   (when (string-match "\.pyi$" (buffer-file-name (current-buffer)))
+     (list "--pyi"))   
    '("-")))
 
 ;;;###autoload


### PR DESCRIPTION
Minor tweak so that calling from the command line and within Emacs produce the same result.