### PR TITLE
Check for file name before comparing as string

### DIFF
--- a/blacken.el
+++ b/blacken.el
@@ -117,7 +117,8 @@ Return black process the exit code."
      (list "--fast"))
    (when blacken-skip-string-normalization
      (list "--skip-string-normalization"))
-   (when (string-match "\.pyi$" (buffer-file-name (current-buffer)))
+   (when (and (buffer-file-name (current-buffer))
+              (string-match "\.pyi$" (buffer-file-name (current-buffer))))
      (list "--pyi"))
    '("-")))
 


### PR DESCRIPTION
Prevent error when blacken-mode is used to edit an org-mode code block