### PR TITLE
Support Black 20

### DIFF
--- a/blacken.el
+++ b/blacken.el
@@ -112,7 +112,7 @@ Return black process the exit code."
                                ('fill fill-column)
                                (t blacken-line-length)))))
    (when blacken-allow-py36
-     (list "--py36"))
+     (list "--target-version" "py36"))
    (when blacken-fast-unsafe
      (list "--fast"))
    (when blacken-skip-string-normalization


### PR DESCRIPTION
Use the option `--target-version` insteead `--py36`, which was removed in Black 20.8b0.

The option `--target-version` was added in Black 19.3b0, so blacken now requires at least this version of Black.

See https://github.com/psf/black/pull/1236