### PR TITLE
make `blacken.el` work with global whitespace mode

### DIFF
--- a/blacken.el
+++ b/blacken.el
@@ -165,9 +165,15 @@ Show black output, if black exit abnormally and DISPLAY is t."
   "Automatically run black before saving."
   :lighter " Black"
   (if blacken-mode
-      (when (or (not blacken-only-if-project-is-blackened)
-                (blacken-project-is-blackened))
-        (add-hook 'before-save-hook 'blacken-buffer nil t))
+      (progn
+        ;; add before save hook to automatically run black
+        (when (or (not blacken-only-if-project-is-blackened)
+                  (blacken-project-is-blackened))
+          (add-hook 'before-save-hook 'blacken-buffer nil t))
+        ;; show overlong lines correctly when using whitespace mode
+        (if blacken-line-length
+            (setq whitespace-line-column blacken-line-length)
+          (setq whitespace-line-column 88)))
     (remove-hook 'before-save-hook 'blacken-buffer t)))
 
 (provide 'blacken)


### PR DESCRIPTION
[Global whitespace mode](http://ergoemacs.org/emacs/whitespace-mode.html) colors overlong lines purple, and `blacken.el` should set `whitespace-line-column` to agree with `blacken-line-length`.

This sets the variable when blacken mode is enabled.