### PR TITLE
Add blacken-target-version, remove blacken-allow-py36

### DIFF
--- a/blacken.el
+++ b/blacken.el
@@ -60,9 +60,9 @@ If `fill', the `fill-column' variable value is used."
            (integer :tag "Line Length"))
   :safe 'integerp)
 
-(defcustom blacken-allow-py36 nil
-  "Allow using Python 3.6-only syntax on all input files."
-  :type 'boolean
+(defcustom blacken-target-version nil
+  "Set the target python version."
+  :type 'string
   :safe 'booleanp)
 
 (defcustom blacken-skip-string-normalization nil
@@ -112,8 +112,8 @@ Return black process the exit code."
            (number-to-string (cl-case blacken-line-length
                                ('fill fill-column)
                                (t blacken-line-length)))))
-   (when blacken-allow-py36
-     (list "--target-version" "py36"))
+   (when blacken-target-version
+     (list "--target-version" blacken-target-version))
    (when blacken-fast-unsafe
      (list "--fast"))
    (when blacken-skip-string-normalization

--- a/blacken.el
+++ b/blacken.el
@@ -4,7 +4,7 @@
 
 ;; Author: Artem Malyshev <proofit404@gmail.com>
 ;; Homepage: https://github.com/proofit404/blacken
-;; Version: 0.0.1
+;; Version: 0.2.0
 ;; Package-Requires: ((emacs "25.2"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -60,10 +60,15 @@ If `fill', the `fill-column' variable value is used."
            (integer :tag "Line Length"))
   :safe 'integerp)
 
+(defcustom blacken-allow-py36 nil
+  "Allow using Python 3.6-only syntax on all input files."
+  :type 'boolean
+  :safe 'booleanp)
+(make-obsolete-variable 'blacken-allow-py36 'blacken-target-version "0.2.0")
+
 (defcustom blacken-target-version nil
   "Set the target python version."
-  :type 'string
-  :safe 'booleanp)
+  :type 'string)
 
 (defcustom blacken-skip-string-normalization nil
   "Don't normalize string quotes or prefixes."
@@ -112,8 +117,10 @@ Return black process the exit code."
            (number-to-string (cl-case blacken-line-length
                                ('fill fill-column)
                                (t blacken-line-length)))))
-   (when blacken-target-version
-     (list "--target-version" blacken-target-version))
+   (if blacken-allow-py36
+       (list "--target-version" "py36")
+     (when blacken-target-version
+       (list "--target-version" blacken-target-version)))
    (when blacken-fast-unsafe
      (list "--fast"))
    (when blacken-skip-string-normalization


### PR DESCRIPTION
Hi! I think having something like `blacken-target-version` instead of a py36 special case would be more preferable.
I can make the `blacken-allow-py36` a deprecated special case if you want to, or I can have it simply deleted. Let me know which way you prefer