### PR TITLE
Don't quote `cl-case` form clause

### DIFF
--- a/blacken.el
+++ b/blacken.el
@@ -39,8 +39,6 @@
 ;;
 ;;; Code:
 
-(require 'cl-lib)
-
 (defgroup blacken nil
   "Reformat Python code with \"black\"."
   :group 'python)
@@ -114,9 +112,9 @@ Return black process the exit code."
   (append
    (when blacken-line-length
      (list "--line-length"
-           (number-to-string (cl-case blacken-line-length
-                               ('fill fill-column)
-                               (t blacken-line-length)))))
+           (number-to-string (if (eq blacken-line-length 'fill)
+                                 fill-column
+                               blacken-line-length))))
    (if blacken-allow-py36
        (list "--target-version" "py36")
      (when blacken-target-version


### PR DESCRIPTION
Quoting the `fill` clause in the `cl-case` form on line 118 was probably not intended, as shown by the following compilation warning:

> Case 'fill will match ‘quote’.  If that’s intended, write (fill quote) instead.  Otherwise, don’t quote ‘fill’.

This could alternatively be rewritten with a simple `if`, losing the dependency on `cl-lib` altogether:

```diff
diff --git a/blacken.el b/blacken.el
index ea1a297..a855e75 100644
--- a/blacken.el
+++ b/blacken.el
@@ -39,8 +39,6 @@
 ;;
 ;;; Code:
 
-(require 'cl-lib)
-
 (defgroup blacken nil
   "Reformat Python code with \"black\"."
   :group 'python)
@@ -114,9 +112,9 @@ Return black process the exit code."
   (append
    (when blacken-line-length
      (list "--line-length"
-           (number-to-string (cl-case blacken-line-length
-                               ('fill fill-column)
-                               (t blacken-line-length)))))
+           (number-to-string (if (eq blacken-line-length 'fill)
+                                 fill-column
+                               blacken-line-length))))
    (if blacken-allow-py36
        (list "--target-version" "py36")
      (when blacken-target-version
```