### PR TITLE
Fix freeze if line length >= 1024

### DIFF
--- a/blacken.el
+++ b/blacken.el
@@ -95,6 +95,7 @@ Return black process the exit code."
                                  :command `(,blacken-executable ,@(blacken-call-args))
                                  :buffer output-buffer
                                  :stderr error-buffer
+                                 :connection-type 'pipe
                                  :noquery t
                                  :sentinel (lambda (process event)))))
       (set-process-query-on-exit-flag (get-buffer-process error-buffer) nil)


### PR DESCRIPTION
Fix `blacken-buffer` freeze if a Python code line length exceeds 1024 characters. For more details and a test case see https://debbugs.gnu.org/cgi/bugreport.cgi?bug=67510