### PR TITLE
Fix for Issue #48: Changed the black executable from string to list …

### DIFF
--- a/blacken.el
+++ b/blacken.el
@@ -48,6 +48,10 @@
   "Name of the executable to run."
   :type 'string)
 
+(defcustom blacken-executable-list '(blacken-executable)
+  "Command (with extra arguments) to invoke black"
+  :type '(repeat string))
+
 (defcustom blacken-line-length nil
   "Line length to enforce.
 
@@ -92,7 +96,7 @@ output to OUTPUT-BUFFER.  Saving process stderr to ERROR-BUFFER.
 Return black process the exit code."
   (with-current-buffer input-buffer
     (let ((process (make-process :name "blacken"
-                                 :command `(,blacken-executable ,@(blacken-call-args))
+                                 :command `(,@blacken-executable-list ,@(blacken-call-args))
                                  :buffer output-buffer
                                  :stderr error-buffer
                                  :connection-type 'pipe


### PR DESCRIPTION
… to allow 'python -m black' to be used instead of just 'black' for the executable name.  This is because black as a standalong executable is not something that is typically supported on windows, but the python module invocation always works, and the zombie processes that were using up file handles for Issue 48 was due to the make-process function failing when it couldn't find a black executable.  Changing blacken-executable to the list fixes this problem (assuming the black module is installed).